### PR TITLE
fix character encoding at header string

### DIFF
--- a/tumblr_backup.py
+++ b/tumblr_backup.py
@@ -55,6 +55,7 @@ def savePost(post, save_folder, header="", use_csv=False, save_file=None):
         f = open(file_name, "w")
 
         # header info which is the same for all posts
+        header = unescape(header)
         f.write(header)
         f.write('<p class="timestamp">' + date_gmt + '</p>')
 


### PR DESCRIPTION
When importing a blog with utf-8 chars in the header it gives UnicodeEncodeError

This fix unescape all the chars using the same function as the rest of the post content.
