### PR TITLE
Fix improper encoding on Ubuntu 14.04

### DIFF
--- a/tumblr_backup.py
+++ b/tumblr_backup.py
@@ -4,6 +4,9 @@ import sys
 import urllib2
 import csv
 
+reload(sys);
+sys.setdefaultencoding('UTF8')
+
 # add BeautifulSoup submobule to path
 lib_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'beautifulsoup')
 sys.path.append(lib_dir)


### PR DESCRIPTION
On Ubuntu 14.04 Python 2.7 seems to have improper encoding which causes the program to fail with 'ascii'-related error when launched with non-English languaged blogs.

There's a chance that the same error is present on all other systems and configs.
